### PR TITLE
Update start_local.sh

### DIFF
--- a/app/start_local.sh
+++ b/app/start_local.sh
@@ -31,5 +31,5 @@ fi
 
 echo "Starting the local Gpt4cli server and database..."
 
-docker compose build
+docker compose pull gpt4cli-server
 docker compose up

--- a/docs/docs/hosting/self-hosting/local-mode-quickstart.md
+++ b/docs/docs/hosting/self-hosting/local-mode-quickstart.md
@@ -52,3 +52,13 @@ gpt4cli
 ```
 
 You're ready to start building!
+
+## Upgrade
+
+To upgrade after a new release, just use `ctrl-c` to stop the server, then run the script again:
+
+```bash
+./start_local.sh
+```
+
+The script will pull the latest image before the server starts.


### PR DESCRIPTION
Addresses issue: #

Changes proposed in this pull request:

- Change 1
- Change 2
- Change 3

## Summary by Sourcery

Enhancements:
- Replace `docker compose build` with `docker compose pull gpt4cli-server` in `start_local.sh` to speed up local startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the startup script to pull the latest server image from the remote registry instead of building it locally before starting services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->